### PR TITLE
chore(claude): add Claude Code agents and CLAUDE.md

### DIFF
--- a/.claude/agents/docs.md
+++ b/.claude/agents/docs.md
@@ -1,0 +1,43 @@
+---
+name: docs
+description: Use for technical documentation updates, API usage docs, and developer-facing explanations based on the Med-Assist codebase.
+tools: Read, Grep, Glob, Edit, Write
+model: sonnet
+---
+
+You are the Med-Assist Docs Agent.
+
+## Role
+- You write and improve technical documentation for developers.
+- You transform code behavior and API contracts into clear, practical docs.
+- You keep docs concise, actionable, and aligned with real code paths.
+
+## Project Knowledge
+- Backend: Python 3.12+, FastAPI 0.128.0, Redis async 7.1.0, Transformers 4.x, PyTorch 2.x.
+- Frontend: Next.js 16.x, React 19.x, TypeScript 5.x, Node.js 24.x.
+- Core flow: upload medical files, validate inputs, extract text, persist to local Redis with UUID keys, extract entities.
+
+## Commands Reference
+You have no Bash tool in this mode. When documentation changes need validation, hand these back to the caller to run:
+- Backend checks: `cd backend && uv run pytest -v && uv run pre-commit run --all-files`
+- Frontend checks: `cd frontend && npm run lint && npm run build && npm test`
+
+## Documentation Standards
+- Be specific about endpoints, payloads, and expected errors.
+- Prefer real examples over abstract descriptions.
+- Keep security/privacy statements explicit for patient data constraints.
+- Keep language consistent with existing project docs.
+
+## Boundaries
+- Always: keep docs aligned with current behavior in code — read the code before documenting it.
+- Ask first: before large structural rewrites of existing docs.
+- Never: invent commands, endpoints, or passing test results.
+- Never: modify production credentials, secrets, or deployment configs.
+- Never: include real patient data in examples.
+
+## Output Format
+Return:
+1. Files updated.
+2. Summary of doc changes.
+3. Validation commands the caller should run (and why they were not run here).
+4. Open assumptions needing confirmation.

--- a/.claude/agents/docs.md
+++ b/.claude/agents/docs.md
@@ -12,15 +12,14 @@ You are the Med-Assist Docs Agent.
 - You transform code behavior and API contracts into clear, practical docs.
 - You keep docs concise, actionable, and aligned with real code paths.
 
-## Project Knowledge
-- Backend: Python 3.12+, FastAPI 0.128.0, Redis async 7.1.0, Transformers 4.x, PyTorch 2.x.
-- Frontend: Next.js 16.x, React 19.x, TypeScript 5.x, Node.js 24.x.
-- Core flow: upload medical files, validate inputs, extract text, persist to local Redis with UUID keys, extract entities.
+## Project Context
+Read `AGENTS.md` first. It is the single source of truth for the stack, the
+core upload/extract/store flow, and the security boundaries. Do not rely on a
+copy here — and when you document any of it, keep AGENTS.md authoritative
+rather than restating it.
 
-## Commands Reference
-You have no Bash tool in this mode. When documentation changes need validation, hand these back to the caller to run:
-- Backend checks: `cd backend && uv run pytest -v && uv run pre-commit run --all-files`
-- Frontend checks: `cd frontend && npm run lint && npm run build && npm test`
+You have no Bash tool. When doc changes need validation, hand the relevant
+gates from AGENTS.md section 1 back to the caller to run.
 
 ## Documentation Standards
 - Be specific about endpoints, payloads, and expected errors.

--- a/.claude/agents/lint.md
+++ b/.claude/agents/lint.md
@@ -12,16 +12,12 @@ You are the Med-Assist Lint Agent.
 - You prioritize safe, mechanical fixes over refactors.
 - You keep style and static checks green across touched files.
 
-## Project Knowledge
-- Backend quality gates: Ruff, mypy, pylint, pre-commit.
-- Frontend quality gates: ESLint and Next.js 16 build on Node.js 24.x.
-- Code must remain compatible with strict security/privacy constraints.
+## Project Context
+Read `AGENTS.md` first. It is the single source of truth for the stack, the
+quality-gate commands, and the security boundaries. Do not rely on a copy here.
 
-## Commands You Can Run
-Run the minimum commands needed to validate changes:
-- Backend lint/type: `cd backend && uv run pre-commit run --all-files`
-- Backend tests safety check: `cd backend && uv run pytest -v`
-- Frontend lint/build: `cd frontend && npm run lint && npm run build`
+Backend gates are Ruff, mypy and pylint via pre-commit; frontend gates are
+ESLint and the Next.js build. Run the minimum needed for the touched scope.
 
 ## Linting Rules
 - Prefer auto-fix paths when safe and available.

--- a/.claude/agents/lint.md
+++ b/.claude/agents/lint.md
@@ -1,0 +1,44 @@
+---
+name: lint
+description: Use for linting and static-check fixes (Ruff, mypy, pylint, ESLint) while preserving runtime behavior and public contracts. Invoke as the first mandatory review pass on any non-trivial change.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: sonnet
+---
+
+You are the Med-Assist Lint Agent.
+
+## Role
+- You fix lint/type issues with minimal, behavior-preserving edits.
+- You prioritize safe, mechanical fixes over refactors.
+- You keep style and static checks green across touched files.
+
+## Project Knowledge
+- Backend quality gates: Ruff, mypy, pylint, pre-commit.
+- Frontend quality gates: ESLint and Next.js 16 build on Node.js 24.x.
+- Code must remain compatible with strict security/privacy constraints.
+
+## Commands You Can Run
+Run the minimum commands needed to validate changes:
+- Backend lint/type: `cd backend && uv run pre-commit run --all-files`
+- Backend tests safety check: `cd backend && uv run pytest -v`
+- Frontend lint/build: `cd frontend && npm run lint && npm run build`
+
+## Linting Rules
+- Prefer auto-fix paths when safe and available.
+- Keep changes small and localized.
+- Do not alter API behavior unless the user asks for functional changes.
+- If a lint fix introduces logic risk, stop and report it instead of guessing.
+
+## Boundaries
+- Always: explain behavior risk when touching non-trivial code paths.
+- Ask first: before dependency changes or large-scale rewrites.
+- Never: silence errors by disabling rules globally without approval.
+- Never: claim checks passed if not executed. Paste the real command output.
+- Never: edit `backend/models/` or `**/__pycache__/`.
+
+## Output Format
+Return:
+1. Files changed (as `path:line` references).
+2. Checks run and results.
+3. Any rule suppressions added and why.
+4. Residual lint/type debt.

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -1,0 +1,42 @@
+---
+name: review
+description: Use for code review, regression analysis, API contract checks, and missing-test detection on Med-Assist changes. Read-only. Invoke as the third mandatory review pass on any non-trivial change.
+tools: Read, Grep, Glob
+model: opus
+---
+
+You are the Med-Assist Review Agent.
+
+## Role
+- You perform behavior-focused code reviews.
+- You identify regressions, breaking API/schema changes, and coverage gaps.
+- You prioritize findings by severity and impact.
+
+## Project Knowledge
+- Backend: Python 3.12+, FastAPI 0.128.0, Redis async 7.1.0, Transformers 4.x, PyTorch 2.x.
+- Frontend: Next.js 16.x, React 19.x, TypeScript 5.x, Node.js 24.x.
+- Primary flow: upload files, validate inputs, extract text, store in local Redis via UUID keys, extract entities.
+
+## Commands Reference
+You have no Bash tool in this mode and must not execute commands. Reference these quality gates in your report so the caller can run them:
+- Backend tests: `cd backend && uv run pytest -v`
+- Backend checks: `cd backend && uv run pre-commit run --all-files`
+- Frontend lint/build/tests: `cd frontend && npm run lint && npm run build && npm test`
+
+## Review Checklist
+1. Validate behavior against the expected flow and endpoint contracts.
+2. Check edge cases, error handling, and backward compatibility.
+3. Check test impact: new logic should have tests; changed behavior should update tests.
+4. Flag suspicious broad exceptions, unsafe defaults, and silent failures.
+
+## Boundaries
+- Always: report concrete, actionable findings with `path:line` references.
+- Ask first: if required context is missing or ambiguous — state the assumption you fell back on.
+- Never: propose style-only nitpicks as high-priority issues.
+- Never: claim checks were run. You cannot run them.
+
+## Output Format
+Return only:
+1. Findings by severity (`high`, `medium`, `low`), each with file path, risk, and fix suggestion.
+2. Open questions/assumptions.
+3. Residual risk/testing gaps if no major findings.

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -12,16 +12,13 @@ You are the Med-Assist Review Agent.
 - You identify regressions, breaking API/schema changes, and coverage gaps.
 - You prioritize findings by severity and impact.
 
-## Project Knowledge
-- Backend: Python 3.12+, FastAPI 0.128.0, Redis async 7.1.0, Transformers 4.x, PyTorch 2.x.
-- Frontend: Next.js 16.x, React 19.x, TypeScript 5.x, Node.js 24.x.
-- Primary flow: upload files, validate inputs, extract text, store in local Redis via UUID keys, extract entities.
+## Project Context
+Read `AGENTS.md` first. It is the single source of truth for the stack, the
+nominal upload/extract/store flow, and the security boundaries. Do not rely on
+a copy here.
 
-## Commands Reference
-You have no Bash tool in this mode and must not execute commands. Reference these quality gates in your report so the caller can run them:
-- Backend tests: `cd backend && uv run pytest -v`
-- Backend checks: `cd backend && uv run pre-commit run --all-files`
-- Frontend lint/build/tests: `cd frontend && npm run lint && npm run build && npm test`
+You have no Bash tool and cannot execute anything. Name the relevant quality
+gates from AGENTS.md section 1 in your report so the caller can run them.
 
 ## Review Checklist
 1. Validate behavior against the expected flow and endpoint contracts.

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -12,18 +12,17 @@ You are the Med-Assist Security Agent.
 - You focus on data confidentiality, trust boundaries, and safe error behavior.
 - You report only actionable, risk-ranked findings.
 
-## Project Knowledge
-- Patient data must remain local.
-- Storage is local Redis with UUID-based keys and a limited retention footprint.
-- No patient content may be sent to external services.
-- Secrets must come only from environment variables.
-- Frontend runs on Next.js 16 and requires Node.js 24.x.
+## Project Context
+Read `AGENTS.md` first, especially section 9 (Security and Data Boundaries).
+It is the single source of truth and lists the boundaries you are auditing
+against. Do not rely on a copy here.
 
-## Commands Reference
-You have no Bash tool in this mode and must not execute commands. Reference these quality gates in your report so the caller can run them:
-- Backend checks: `cd backend && uv run pre-commit run --all-files`
-- Backend tests: `cd backend && uv run pytest -v`
-- Frontend checks: `cd frontend && npm run lint && npm run build && npm test`
+Non-negotiables in short: patient data stays local, storage is local Redis with
+UUID keys, no patient content leaves for external services, secrets come only
+from environment variables.
+
+You have no Bash tool and cannot execute anything. Name the relevant quality
+gates from AGENTS.md section 1 in your report so the caller can run them.
 
 ## Security Checklist
 1. Check for data leakage in logs, exceptions, fixtures, responses, and telemetry.

--- a/.claude/agents/security.md
+++ b/.claude/agents/security.md
@@ -1,0 +1,48 @@
+---
+name: security
+description: Use for security and privacy review, including patient data exposure, secret handling, input validation, and Redis/local boundary risks. Read-only. Invoke as the fourth mandatory review pass on any non-trivial change.
+tools: Read, Grep, Glob
+model: opus
+---
+
+You are the Med-Assist Security Agent.
+
+## Role
+- You perform privacy and security reviews for Med-Assist changes.
+- You focus on data confidentiality, trust boundaries, and safe error behavior.
+- You report only actionable, risk-ranked findings.
+
+## Project Knowledge
+- Patient data must remain local.
+- Storage is local Redis with UUID-based keys and a limited retention footprint.
+- No patient content may be sent to external services.
+- Secrets must come only from environment variables.
+- Frontend runs on Next.js 16 and requires Node.js 24.x.
+
+## Commands Reference
+You have no Bash tool in this mode and must not execute commands. Reference these quality gates in your report so the caller can run them:
+- Backend checks: `cd backend && uv run pre-commit run --all-files`
+- Backend tests: `cd backend && uv run pytest -v`
+- Frontend checks: `cd frontend && npm run lint && npm run build && npm test`
+
+## Security Checklist
+1. Check for data leakage in logs, exceptions, fixtures, responses, and telemetry.
+2. Validate input boundaries (file type, extension, UUID format, request size assumptions).
+3. Verify secret handling (no hardcoded credentials/tokens, env-only config).
+4. Check Redis key/value safety (no patient-identifiable keys, retention awareness).
+5. Confirm local-first boundaries (no external egress for sensitive content).
+6. Check CORS and production-boundary changes for overexposure.
+
+## Boundaries
+- Always: map findings to impact and practical remediation.
+- Ask first: before accepting risky trade-offs.
+- Never: ignore potential high-impact leaks.
+- Never: include patient data samples in the report. Redact and describe instead.
+
+## Output Format
+Return only actionable findings with:
+- Severity (`critical`, `high`, `medium`, `low`)
+- Category (use a CWE-style label when applicable)
+- Affected file path(s)
+- Impact
+- Recommended mitigation

--- a/.claude/agents/test.md
+++ b/.claude/agents/test.md
@@ -12,16 +12,12 @@ You are the Med-Assist Test Agent.
 - You increase confidence with focused unit/integration tests and edge cases.
 - You report failures with likely root cause and concrete next actions.
 
-## Project Knowledge
-- Backend tests: pytest (including async tests) under `backend/tests/` and root-level backend test files.
-- Frontend checks: ESLint and Next.js 16 build on Node.js 24.x, with `npm test` as a required test gate.
-- Sensitive context: medical document processing with strict privacy constraints.
+## Project Context
+Read `AGENTS.md` first. It is the single source of truth for the stack, the
+quality-gate commands, and the security boundaries. Do not rely on a copy here.
 
-## Commands You Can Run
-Run only what is needed for the touched scope:
-- Backend focused tests: `cd backend && uv run pytest -v`
-- Backend full checks: `cd backend && uv run pre-commit run --all-files`
-- Frontend checks: `cd frontend && npm run lint && npm run build && npm test`
+Backend tests are pytest (including async) under `backend/tests/` and root-level
+backend test files. Run only what is needed for the touched scope.
 
 ## Testing Rules
 - Add or update tests for every functional change.

--- a/.claude/agents/test.md
+++ b/.claude/agents/test.md
@@ -1,0 +1,44 @@
+---
+name: test
+description: Use for creating or updating tests, expanding edge-case coverage, and improving test reliability without changing business logic. Invoke as the second mandatory review pass on any non-trivial change.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: sonnet
+---
+
+You are the Med-Assist Test Agent.
+
+## Role
+- You write and update tests for backend and frontend changes.
+- You increase confidence with focused unit/integration tests and edge cases.
+- You report failures with likely root cause and concrete next actions.
+
+## Project Knowledge
+- Backend tests: pytest (including async tests) under `backend/tests/` and root-level backend test files.
+- Frontend checks: ESLint and Next.js 16 build on Node.js 24.x, with `npm test` as a required test gate.
+- Sensitive context: medical document processing with strict privacy constraints.
+
+## Commands You Can Run
+Run only what is needed for the touched scope:
+- Backend focused tests: `cd backend && uv run pytest -v`
+- Backend full checks: `cd backend && uv run pre-commit run --all-files`
+- Frontend checks: `cd frontend && npm run lint && npm run build && npm test`
+
+## Testing Rules
+- Add or update tests for every functional change.
+- Prefer focused tests first, then the broader suite.
+- Keep assertions behavior-oriented, not implementation-coupled.
+- Include negative/edge cases for validation and error flows.
+- Never use real or realistic patient data in fixtures; use synthetic, obviously-fake values.
+
+## Boundaries
+- Always: preserve existing failing tests unless the user explicitly approves removal.
+- Ask first: before introducing heavy fixtures or broad snapshot rewrites.
+- Never: change production code logic just to make tests pass without approval.
+- Never: fabricate green test results. If `npm test` is not configured yet, say so — do not report it as passing.
+
+## Output Format
+Return:
+1. Tests added/updated (with file paths).
+2. Commands executed and pass/fail status.
+3. Failing tests with probable root cause.
+4. Remaining coverage gaps.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,11 +105,15 @@ Expected behavior:
 
 ## 8) Mandatory Subagent Review Workflow
 
-For any non-trivial change, run four separate subagent passes before finalizing:
+For any non-trivial change, run four separate subagent passes before finalizing.
+
+Each agent tool defines these four roles in its own format. Do not hardcode one
+tool's paths here — this section defines the passes, and each tool maps them:
+
+- GitHub: `.github/agents/*.agent.md`, invoked as `@Lint Agent <prompt>`.
+- Claude Code: `.claude/agents/*.md`, mapped in `CLAUDE.md`.
 
 1. Lint pass (static checks and formatting safety)
-- Preferred subagent: `Lint Agent` in `.github/agents/lint.agent.md`.
-- Fallback subagent: `Explore` with a lint-focused prompt.
 - Goal: detect/fix lint and static-analysis issues without changing behavior.
 - Expected output: files changed, checks run, results, and any residual lint debt.
 
@@ -122,8 +126,6 @@ executed checks, and remaining lint/type debt.
 ```
 
 2. Test pass (coverage and reliability)
-- Preferred subagent: `Test Agent` in `.github/agents/test.agent.md`.
-- Fallback subagent: `Explore` with a test-focused prompt.
 - Goal: ensure tests are added/updated and quality gates are executed for touched scope.
 - Expected output: tests added/updated, commands executed, failures, and coverage gaps.
 
@@ -136,8 +138,6 @@ failures with root-cause hypotheses, and remaining coverage gaps.
 ```
 
 3. Review pass (behavior and regressions)
-- Preferred subagent: `Review Agent` in `.github/agents/review.agent.md`.
-- Fallback subagent: `Explore` with a review-focused prompt.
 - Goal: find functional bugs, regressions, API contract breaks, and missing tests.
 - Expected output: prioritized findings with file paths, risk level, and proposed fixes.
 
@@ -150,8 +150,6 @@ Return findings ordered by severity with concrete file references and fix sugges
 ```
 
 4. Security pass (privacy and boundaries)
-- Preferred subagent: `Security Agent` in `.github/agents/security.agent.md`.
-- Fallback subagent: `Explore` with a security-focused prompt.
 - Goal: detect confidentiality leaks, unsafe error handling, weak input validation, and boundary violations.
 - Expected output: security findings with CWE-style category when relevant, impact, and mitigation.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,199 +1,41 @@
 # CLAUDE.md - Med-Assist
 
-Guidance for Claude Code when working in this repository.
+The project spec lives in AGENTS.md and is the single source of truth for
+commands, stack, structure, security boundaries, and definition of done.
 
-## 1) Quick Commands (Run These First)
+@AGENTS.md
 
-Run commands from the project root unless stated otherwise.
+Everything below is the Claude-Code-specific delta. If a rule here conflicts
+with AGENTS.md, AGENTS.md wins — except where noted as Claude-only mechanics.
 
-Environment baseline:
-- Frontend targets Node.js 24.x.
-- Current validated local setup uses Node.js 24 managed by `n`.
+## Subagent Mapping
 
-```bash
-# Backend quality gates
-cd backend
-uv run pytest -v
-uv run pre-commit run --all-files
+AGENTS.md section 8 defines four mandatory review passes. In Claude Code they
+map to project subagents in `.claude/agents/`. Invoke them with the Agent tool
+using the `subagent_type` below.
 
-# Frontend quality gates
-cd ../frontend
-npm run lint
-npm run build
-npm test
-```
+| Pass | `subagent_type` | Writes? | Fallback |
+| --- | --- | --- | --- |
+| 1. Lint | `lint` | yes | `Explore`, lint-focused prompt |
+| 2. Test | `test` | yes | `Explore`, test-focused prompt |
+| 3. Review | `review` | no | `/code-review high` |
+| 4. Security | `security` | no | `/security-review` |
 
-Notes:
-- If `npm test` is not configured yet, treat it as a required future gate and do not invent fake passing results.
-- Never mark a task as complete without running the relevant checks for touched code.
+`docs` is also available for documentation work. It is not one of the four gates.
 
-## 2) Product Mission
+Claude-only mechanics:
 
-Med-Assist helps clinicians obtain an actionable summary from one or multiple medical documents.
+- Passes 1 and 2 write and must run in order. Passes 3 and 4 are read-only and
+  independent — launch both in a single message so they run concurrently.
+- `review`, `security` and `docs` have no Bash tool. They cannot run the quality
+  gates; they report which ones you should run.
+- Subagent reports are not shown to the user. Relay the findings that matter in
+  your own response, and never predict or fabricate the result of a pass that
+  has not returned yet.
 
-The system must prioritize:
-- Clinical clarity of outputs.
-- Patient data confidentiality.
-- Technical robustness in local environments.
+## Claude-Specific Notes
 
-## 3) Tech Stack
-
-- Backend: Python 3.12+, FastAPI `0.128.0`, Redis async client `7.1.0`, Transformers `4.x`, PyTorch `2.x`.
-- Frontend: Next.js `16.x`, React `19.x`, TypeScript `5.x`, ESLint `9.x`, Node.js `24.x`.
-- Storage: local Redis only, UUID-based keys, limited retention footprint.
-- Infra: Docker Compose with `redis`, `backend`, and `frontend` services.
-
-## 4) Project Structure
-
-- `backend/app/api/routes/`: HTTP routes (`uploads`, `extractions`, `health`, `mock`).
-- `backend/app/services/`: extraction and file processing logic.
-- `backend/app/repositories/` and `backend/app/db/`: Redis-backed persistence layer.
-- `backend/tests/` + root-level backend tests: unit/integration tests.
-- `frontend/app/`: Next.js app router pages and components.
-
-Nominal flow:
-1. Upload one or multiple medical files (PDF, DOC, DOCX, TXT).
-2. Validate MIME type and extension.
-3. Extract text.
-4. Store extracted content and batch references in local Redis using UUID keys.
-5. Extract medical entities and return API response.
-
-## 5) Testing and Validation Rules
-
-- Add or update tests for every functional change.
-- Prefer focused tests first, then full suite.
-- Keep backend lint/type checks green: Ruff, mypy, pylint, pre-commit.
-- Keep frontend lint/build green: ESLint and Next.js build.
-- Do not silently skip failing checks; report failures with likely root cause.
-
-## 6) Code Style and Output Expectations
-
-- Make small, reversible, testable changes.
-- Preserve public API contracts unless explicitly asked to change them.
-- Keep error messages safe: no stack traces, secrets, or patient identifiers in responses.
-- Validate external input boundaries (file type, extension, ID format).
-
-One concrete example of expected backend style:
-
-```python
-from uuid import UUID
-
-from fastapi import HTTPException
-
-
-def parse_file_id(raw_file_id: str) -> UUID:
-	"""Validate and convert a file id to UUID without leaking internals."""
-	try:
-		return UUID(raw_file_id)
-	except ValueError as exc:
-		raise HTTPException(
-			status_code=400,
-			detail={"message": "Invalid file ID format. Expected UUID."},
-		) from exc
-```
-
-Expected behavior:
-- Deterministic validation.
-- Explicit user-safe error payload.
-- No internal traceback exposure in API response.
-
-## 7) Git Workflow
-
-- Use short-lived branches: `feature/<scope>` or `fix/<scope>`.
-- Commit in logical units with clear messages.
-- Run quality gates before opening a PR.
-- Do not rewrite shared history unless explicitly requested.
-- In reviews, prioritize security, regressions, and missing tests over style-only comments.
-
-## 8) Mandatory Subagent Review Workflow
-
-Project subagents live in `.claude/agents/`. Invoke them with the Agent tool using the
-`subagent_type` shown below, or let the user call them by name.
-
-For any non-trivial change, run four separate subagent passes before finalizing.
-Passes 1 and 2 write; passes 3 and 4 are read-only. Passes 3 and 4 are independent
-of each other and should be launched in the same message so they run concurrently.
-
-### 1. Lint pass (static checks and formatting safety)
-- Subagent: `lint` (`.claude/agents/lint.md`). Fallback: `Explore` with a lint-focused prompt.
-- Goal: detect/fix lint and static-analysis issues without changing behavior.
-- Expected output: files changed, checks run, results, and any residual lint debt.
-
-```text
-Run a lint/static-check pass in medium mode.
-Focus on minimal, behavior-preserving fixes and report changed files,
-executed checks, and remaining lint/type debt.
-```
-
-### 2. Test pass (coverage and reliability)
-- Subagent: `test` (`.claude/agents/test.md`). Fallback: `Explore` with a test-focused prompt.
-- Goal: ensure tests are added/updated and quality gates are executed for touched scope.
-- Expected output: tests added/updated, commands executed, failures, and coverage gaps.
-
-```text
-Run a test pass in medium mode.
-Focus on missing/updated tests for changed behavior and report executed test commands,
-failures with root-cause hypotheses, and remaining coverage gaps.
-```
-
-### 3. Review pass (behavior and regressions)
-- Subagent: `review` (`.claude/agents/review.md`). Fallback: `/code-review high`, or `Explore` with a review-focused prompt.
-- Goal: find functional bugs, regressions, API contract breaks, and missing tests.
-- Expected output: prioritized findings with file paths, risk level, and proposed fixes.
-
-```text
-Review this change set in thorough mode.
-Focus on behavior regressions, edge cases, API/schema compatibility, and missing tests.
-Return findings ordered by severity with concrete file references and fix suggestions.
-```
-
-### 4. Security pass (privacy and boundaries)
-- Subagent: `security` (`.claude/agents/security.md`). Fallback: `/security-review`, or `Explore` with a security-focused prompt.
-- Goal: detect confidentiality leaks, unsafe error handling, weak input validation, and boundary violations.
-- Expected output: security findings with CWE-style category when relevant, impact, and mitigation.
-
-```text
-Perform a security review of this change set in thorough mode.
-Focus on patient data exposure, secret handling, input validation, Redis key safety,
-external data egress, and production config boundaries.
-Return only actionable findings with severity, affected files, and remediation steps.
-```
-
-### Documentation (as needed, not part of the four gates)
-- Subagent: `docs` (`.claude/agents/docs.md`) for API usage docs and developer-facing explanations.
-
-Required merge condition:
-- Lint pass completed with no unresolved high-impact lint/type issues.
-- Test pass completed with relevant tests/checks executed for touched scope.
-- No unresolved high-severity review or security findings.
-- If findings exist, either fix them or document an explicit risk acceptance.
-
-Subagent reports are not shown to the user — relay the findings that matter in your own
-response, and never fabricate or predict the result of a pass that has not returned.
-
-## 9) Security and Data Boundaries (Never Cross)
-
-Never do any of the following:
-- Never expose patient data in logs, error payloads, traces, fixtures, or screenshots.
-- Never hardcode secrets or tokens in code, tests, or docs.
-- Never send patient content to external APIs or cloud services.
-- Never use patient-identifiable values as Redis keys.
-- Never modify production deployment configs or credentials as part of routine feature work.
-- Never edit dependency/vendor/model artifact directories unless explicitly requested:
-  - `backend/models/`
-  - `**/__pycache__/`
-
-Always do:
-- Keep secrets in environment variables only.
-- Keep CORS strict and environment-aligned.
-- Minimize persisted data and justify any new persistent field.
-- Prefer explicit Redis TTLs when retention is introduced.
-
-## 10) Definition of Done
-
-A task is complete only when:
-- Requested behavior is implemented.
-- Related tests pass.
-- Lint/type checks pass for touched areas.
-- Security and privacy requirements above are preserved.
-- Documentation is updated when behavior or constraints change.
+- Node.js is 24.x. The files under `.github/agents/` still say 20.19+; AGENTS.md
+  is correct.
+- `.claude/agents/` and `.github/agents/` are parallel definitions of the same
+  four roles in incompatible frontmatter formats. Change both or neither.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,199 @@
+# CLAUDE.md - Med-Assist
+
+Guidance for Claude Code when working in this repository.
+
+## 1) Quick Commands (Run These First)
+
+Run commands from the project root unless stated otherwise.
+
+Environment baseline:
+- Frontend targets Node.js 24.x.
+- Current validated local setup uses Node.js 24 managed by `n`.
+
+```bash
+# Backend quality gates
+cd backend
+uv run pytest -v
+uv run pre-commit run --all-files
+
+# Frontend quality gates
+cd ../frontend
+npm run lint
+npm run build
+npm test
+```
+
+Notes:
+- If `npm test` is not configured yet, treat it as a required future gate and do not invent fake passing results.
+- Never mark a task as complete without running the relevant checks for touched code.
+
+## 2) Product Mission
+
+Med-Assist helps clinicians obtain an actionable summary from one or multiple medical documents.
+
+The system must prioritize:
+- Clinical clarity of outputs.
+- Patient data confidentiality.
+- Technical robustness in local environments.
+
+## 3) Tech Stack
+
+- Backend: Python 3.12+, FastAPI `0.128.0`, Redis async client `7.1.0`, Transformers `4.x`, PyTorch `2.x`.
+- Frontend: Next.js `16.x`, React `19.x`, TypeScript `5.x`, ESLint `9.x`, Node.js `24.x`.
+- Storage: local Redis only, UUID-based keys, limited retention footprint.
+- Infra: Docker Compose with `redis`, `backend`, and `frontend` services.
+
+## 4) Project Structure
+
+- `backend/app/api/routes/`: HTTP routes (`uploads`, `extractions`, `health`, `mock`).
+- `backend/app/services/`: extraction and file processing logic.
+- `backend/app/repositories/` and `backend/app/db/`: Redis-backed persistence layer.
+- `backend/tests/` + root-level backend tests: unit/integration tests.
+- `frontend/app/`: Next.js app router pages and components.
+
+Nominal flow:
+1. Upload one or multiple medical files (PDF, DOC, DOCX, TXT).
+2. Validate MIME type and extension.
+3. Extract text.
+4. Store extracted content and batch references in local Redis using UUID keys.
+5. Extract medical entities and return API response.
+
+## 5) Testing and Validation Rules
+
+- Add or update tests for every functional change.
+- Prefer focused tests first, then full suite.
+- Keep backend lint/type checks green: Ruff, mypy, pylint, pre-commit.
+- Keep frontend lint/build green: ESLint and Next.js build.
+- Do not silently skip failing checks; report failures with likely root cause.
+
+## 6) Code Style and Output Expectations
+
+- Make small, reversible, testable changes.
+- Preserve public API contracts unless explicitly asked to change them.
+- Keep error messages safe: no stack traces, secrets, or patient identifiers in responses.
+- Validate external input boundaries (file type, extension, ID format).
+
+One concrete example of expected backend style:
+
+```python
+from uuid import UUID
+
+from fastapi import HTTPException
+
+
+def parse_file_id(raw_file_id: str) -> UUID:
+	"""Validate and convert a file id to UUID without leaking internals."""
+	try:
+		return UUID(raw_file_id)
+	except ValueError as exc:
+		raise HTTPException(
+			status_code=400,
+			detail={"message": "Invalid file ID format. Expected UUID."},
+		) from exc
+```
+
+Expected behavior:
+- Deterministic validation.
+- Explicit user-safe error payload.
+- No internal traceback exposure in API response.
+
+## 7) Git Workflow
+
+- Use short-lived branches: `feature/<scope>` or `fix/<scope>`.
+- Commit in logical units with clear messages.
+- Run quality gates before opening a PR.
+- Do not rewrite shared history unless explicitly requested.
+- In reviews, prioritize security, regressions, and missing tests over style-only comments.
+
+## 8) Mandatory Subagent Review Workflow
+
+Project subagents live in `.claude/agents/`. Invoke them with the Agent tool using the
+`subagent_type` shown below, or let the user call them by name.
+
+For any non-trivial change, run four separate subagent passes before finalizing.
+Passes 1 and 2 write; passes 3 and 4 are read-only. Passes 3 and 4 are independent
+of each other and should be launched in the same message so they run concurrently.
+
+### 1. Lint pass (static checks and formatting safety)
+- Subagent: `lint` (`.claude/agents/lint.md`). Fallback: `Explore` with a lint-focused prompt.
+- Goal: detect/fix lint and static-analysis issues without changing behavior.
+- Expected output: files changed, checks run, results, and any residual lint debt.
+
+```text
+Run a lint/static-check pass in medium mode.
+Focus on minimal, behavior-preserving fixes and report changed files,
+executed checks, and remaining lint/type debt.
+```
+
+### 2. Test pass (coverage and reliability)
+- Subagent: `test` (`.claude/agents/test.md`). Fallback: `Explore` with a test-focused prompt.
+- Goal: ensure tests are added/updated and quality gates are executed for touched scope.
+- Expected output: tests added/updated, commands executed, failures, and coverage gaps.
+
+```text
+Run a test pass in medium mode.
+Focus on missing/updated tests for changed behavior and report executed test commands,
+failures with root-cause hypotheses, and remaining coverage gaps.
+```
+
+### 3. Review pass (behavior and regressions)
+- Subagent: `review` (`.claude/agents/review.md`). Fallback: `/code-review high`, or `Explore` with a review-focused prompt.
+- Goal: find functional bugs, regressions, API contract breaks, and missing tests.
+- Expected output: prioritized findings with file paths, risk level, and proposed fixes.
+
+```text
+Review this change set in thorough mode.
+Focus on behavior regressions, edge cases, API/schema compatibility, and missing tests.
+Return findings ordered by severity with concrete file references and fix suggestions.
+```
+
+### 4. Security pass (privacy and boundaries)
+- Subagent: `security` (`.claude/agents/security.md`). Fallback: `/security-review`, or `Explore` with a security-focused prompt.
+- Goal: detect confidentiality leaks, unsafe error handling, weak input validation, and boundary violations.
+- Expected output: security findings with CWE-style category when relevant, impact, and mitigation.
+
+```text
+Perform a security review of this change set in thorough mode.
+Focus on patient data exposure, secret handling, input validation, Redis key safety,
+external data egress, and production config boundaries.
+Return only actionable findings with severity, affected files, and remediation steps.
+```
+
+### Documentation (as needed, not part of the four gates)
+- Subagent: `docs` (`.claude/agents/docs.md`) for API usage docs and developer-facing explanations.
+
+Required merge condition:
+- Lint pass completed with no unresolved high-impact lint/type issues.
+- Test pass completed with relevant tests/checks executed for touched scope.
+- No unresolved high-severity review or security findings.
+- If findings exist, either fix them or document an explicit risk acceptance.
+
+Subagent reports are not shown to the user — relay the findings that matter in your own
+response, and never fabricate or predict the result of a pass that has not returned.
+
+## 9) Security and Data Boundaries (Never Cross)
+
+Never do any of the following:
+- Never expose patient data in logs, error payloads, traces, fixtures, or screenshots.
+- Never hardcode secrets or tokens in code, tests, or docs.
+- Never send patient content to external APIs or cloud services.
+- Never use patient-identifiable values as Redis keys.
+- Never modify production deployment configs or credentials as part of routine feature work.
+- Never edit dependency/vendor/model artifact directories unless explicitly requested:
+  - `backend/models/`
+  - `**/__pycache__/`
+
+Always do:
+- Keep secrets in environment variables only.
+- Keep CORS strict and environment-aligned.
+- Minimize persisted data and justify any new persistent field.
+- Prefer explicit Redis TTLs when retention is introduced.
+
+## 10) Definition of Done
+
+A task is complete only when:
+- Requested behavior is implemented.
+- Related tests pass.
+- Lint/type checks pass for touched areas.
+- Security and privacy requirements above are preserved.
+- Documentation is updated when behavior or constraints change.


### PR DESCRIPTION
Adapts the five agent definitions in `.github/agents/` to Claude Code subagents under `.claude/agents/`, and wires Claude Code into `AGENTS.md` without duplicating it.

## Agent frontmatter mapping

| GitHub | Claude Code |
| --- | --- |
| `name: Lint Agent` | `name: lint` (kebab-case — this is the `subagent_type`) |
| `tools: [read, search, edit, execute]` | `tools: Read, Grep, Glob, Edit, Write, Bash` |
| `user-invocable: true` | dropped — implicit for project agents |
| — | `model:` added (`sonnet` for lint/test/docs, `opus` for review/security) |

Tool mapping: `read`→`Read`, `search`→`Grep, Glob`, `edit`→`Edit, Write`, `execute`→`Bash`.

`review`, `security` and `docs` get no `Bash` tool, so their "do not execute commands in this mode" instruction was rewritten to say they *cannot* and must hand the quality gates back to the caller — in Claude Code that constraint is enforced by the tool list rather than by instruction.

## AGENTS.md stays the single source of truth

The first commit ported AGENTS.md into a full 205-line CLAUDE.md. The second commit collapses that, because two hand-maintained copies of the same spec will drift — and demonstrably already had (see below).

- **CLAUDE.md is 41 lines.** It imports the spec with `@AGENTS.md` and keeps only the Claude-specific delta: the subagent mapping table, the fact that the read-only passes 3 and 4 are independent and should run concurrently, and the tool constraints.
- **AGENTS.md section 8 is now tool-neutral.** It no longer hardcodes `.github/agents/` paths or the `@Lint Agent` mention syntax. It defines the four passes; each tool maps them in its own file.
- **The five `.claude` agents no longer restate the stack, versions, or gate commands.** They point at AGENTS.md and read it.

## Note for reviewers

**There is a real drift bug in `.github/agents/`.** All five GitHub agent files say "Node.js 20.19+"; AGENTS.md says 24.x and documents the validated local setup. The Claude agents use 24.x. The GitHub files are unchanged in this PR and still carry the stale version — worth a follow-up.

That drift is exactly what the de-duplication above is meant to prevent, and it's why the `.claude` agents point at AGENTS.md instead of copying it.

`.github/agents/` is otherwise left in place: it's consumed by GitHub tooling and its frontmatter format isn't compatible with Claude Code's, so the two agent directories can't be merged the way the two markdown specs could.

No source code touched; docs and agent config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)