### PR TITLE
feat: close the gap between the README and the code (phase 0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Copy to .env before running `docker compose up`, then fill in a real password.
+#   cp .env.example .env
+
+# Required. Protects the Redis instance holding extracted clinical text.
+# Use a long, random, URL-safe value - it is embedded in REDIS_URL.
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+REDIS_PASSWORD=
+
+# How long extracted text is kept before Redis deletes it automatically.
+RETENTION_TTL_SECONDS=3600
+
+# Memory ceiling for Redis. Nothing is written to disk, so this bounds retention.
+REDIS_MAXMEMORY=256mb
+
+# Set to `development` only to expose the mock endpoints. Never in a deployment.
+APP_ENV=production
+
+# The URL the browser uses to reach the backend. Baked into the frontend bundle
+# at build time, so changing it requires a rebuild of the frontend image.
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -19,7 +19,21 @@ It is not intended for use in clinical decision-making and should not replace pr
   Med-Assist runs entirely on your infrastructure—no external APIs or cloud dependencies.
 
 - **Secure storage**
-  All data is stored in a local Redis instance, ensuring patient information remains private and compliant with data protection regulations.
+  All data is stored in a local Redis instance that is reachable only from the internal Docker network, requires a password, and never writes to disk.
+
+- **Automatic deletion**
+  Every stored document expires after `RETENTION_TTL_SECONDS` (one hour by default), and the remaining time is shown in the interface. `DELETE /api/documents/{file_id}` removes a document immediately.
+
+---
+
+## 🚀 Running Locally
+
+```bash
+cp .env.example .env      # then set REDIS_PASSWORD to a long random value
+docker compose up --build
+```
+
+The interface is served at [http://localhost:3000](http://localhost:3000) and the API at [http://localhost:8000](http://localhost:8000).
 
 ---
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -29,14 +29,24 @@ The application uses Redis for storing extracted text and processing results. Co
 
 **Environment Variables:**
 
-* `APP_ENV`: Environment mode for the backend. Set to `development` to enable development-only features such as mock endpoints. For production, use `production` or leave unset.
-* `REDIS_URL`: Redis connection URL (default: `redis://localhost:6379`)
+* `APP_ENV`: Environment mode for the backend. Defaults to `production`. Set to `development` to enable development-only features such as mock endpoints; they are never mounted unless you opt in explicitly.
+* `REDIS_URL`: Redis connection URL (default: `redis://localhost:6379`). Include the password when Redis requires one: `redis://:<password>@localhost:6379/0`.
+* `RETENTION_TTL_SECONDS`: Lifetime of every stored value, in seconds (default: `3600`). Every key written by the application carries this expiry, so extracted text is deleted automatically.
 
 **Example:**
 
 ```bash
 export REDIS_URL="redis://localhost:6379"
+export RETENTION_TTL_SECONDS=3600
 ```
+
+### Data retention
+
+Extracted text is never stored indefinitely:
+
+* Every key is written with an expiry of `RETENTION_TTL_SECONDS`.
+* `GET /api/get_extracted_text/{file_id}` and `POST /api/upload_document/` return `expires_in_seconds` so a client can show the remaining time.
+* `DELETE /api/documents/{file_id}` removes a document before its window closes. It answers `204` on success and `404` when nothing was stored.
 
 ### NER Model Configuration
 

--- a/backend/app/api/routes/extractions.py
+++ b/backend/app/api/routes/extractions.py
@@ -8,6 +8,7 @@ from app.schemas.extraction import ExtractionResponse, ErrorResponse, ExtractedE
 from app.repositories.text_repository import TextRepositoryInterface
 from app.services.entity_extractor import EntityExtractor
 from app.core.dependencies import get_text_repository, get_entity_extractor
+from app.core.validation import parse_file_id
 
 router = APIRouter()
 
@@ -49,16 +50,7 @@ async def get_extracted_text(
     Raises:
         HTTPException: 404 if file not found or not processed yet
     """
-    # Convert file_id to UUID
-    try:
-        file_uuid: UUID = UUID(file_id)
-    except ValueError as exc:
-        # If file_id is not a valid UUID, create a deterministic approach
-        # For now, we'll raise an error since we expect valid UUIDs
-        raise HTTPException(
-            status_code=400,
-            detail={"message": "Invalid file ID format. Expected UUID."},
-        ) from exc
+    file_uuid: UUID = parse_file_id(file_id)
 
     extracted_entities = await extract_entities(
         file_uuid, text_repository, entity_extractor
@@ -77,4 +69,5 @@ async def get_extracted_text(
         text=text or "",
         extracted_entities=ExtractedEntities(**extracted_entities),
         mapping_info=entity_extractor.get_mapping_info(),
+        expires_in_seconds=await text_repository.get_text_ttl(file_uuid),
     )

--- a/backend/app/api/routes/uploads.py
+++ b/backend/app/api/routes/uploads.py
@@ -2,7 +2,7 @@ import logging
 from typing import List, Union
 from uuid import uuid4
 
-from fastapi import APIRouter, HTTPException, File, UploadFile, Depends
+from fastapi import APIRouter, HTTPException, File, Path, UploadFile, Depends, status
 
 from app.schemas.upload import (
     FileValidationError,
@@ -12,8 +12,10 @@ from app.schemas.upload import (
 )
 from app.use_cases.save_file import save_batch, save_file
 from app.use_cases.validate_file import validate_upload_file
+from app.interfaces.repositories_interfaces import TextRepositoryInterface
 from app.services.file_handler import FileHandler
-from app.core.dependencies import get_file_handler
+from app.core.dependencies import get_file_handler, get_text_repository
+from app.core.validation import parse_file_id
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -34,6 +36,7 @@ logger = logging.getLogger(__name__)
 async def upload_document(
     file: UploadFile = File(..., description="The file to upload (PDF, DOCX, TXT)."),
     file_handler: FileHandler = Depends(get_file_handler),
+    text_repository: TextRepositoryInterface = Depends(get_text_repository),
 ):
     """
     Upload a medical document for text extraction and entity recognition.
@@ -64,6 +67,7 @@ async def upload_document(
             file_id=str(file_id),
             filename=file.filename or "unknown",
             message="File uploaded successfully. Extraction pending.",
+            expires_in_seconds=await text_repository.get_text_ttl(file_id),
         )
     except HTTPException:
         raise
@@ -147,3 +151,37 @@ async def upload_documents(
         file_ids=file_ids,
         message="Files uploaded successfully.",
     )
+
+
+@router.delete(
+    "/documents/{file_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        204: {"description": "Document deleted"},
+        400: {"model": UploadErrorResponse, "description": "Invalid file ID format"},
+        404: {"model": UploadErrorResponse, "description": "Document not found"},
+    },
+)
+async def delete_document(
+    file_id: str = Path(
+        ...,
+        description="Unique identifier of the document to delete",
+        examples=["123e4567-e89b-12d3-a456-426614174000"],
+    ),
+    text_repository: TextRepositoryInterface = Depends(get_text_repository),
+) -> None:
+    """
+    Delete a stored document before its retention window expires.
+
+    Args:
+        file_id: The unique identifier of the document to delete
+        text_repository: Injected text repository dependency
+
+    Raises:
+        HTTPException: 400 for a malformed file ID, 404 if nothing was stored
+    """
+    if not await text_repository.delete_text(parse_file_id(file_id)):
+        raise HTTPException(
+            status_code=404,
+            detail={"message": "Document not found or already expired."},
+        )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -10,6 +10,12 @@ class RedisConfiguration(BaseSettings):
     )
 
     url: RedisDsn = Field(..., alias="REDIS_URL")
+    retention_ttl_seconds: int = Field(
+        default=3600,
+        alias="RETENTION_TTL_SECONDS",
+        gt=0,
+        description="Lifetime of every stored value, in seconds.",
+    )
 
 
 class NERModelConfiguration(BaseSettings):

--- a/backend/app/core/validation.py
+++ b/backend/app/core/validation.py
@@ -1,0 +1,16 @@
+"""Shared input validation helpers for the API boundary."""
+
+from uuid import UUID
+
+from fastapi import HTTPException
+
+
+def parse_file_id(raw_file_id: str) -> UUID:
+    """Validate and convert a file id to UUID without leaking internals."""
+    try:
+        return UUID(raw_file_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={"message": "Invalid file ID format. Expected UUID."},
+        ) from exc

--- a/backend/app/db/redis.py
+++ b/backend/app/db/redis.py
@@ -8,11 +8,22 @@ class RedisStorage:
         self.config = config
         self.client = redis.Redis.from_url(str(self.config.url))
 
-    async def store_value(self, key: str, value: str):
-        """Set a value in Redis."""
-        await self.client.set(key, value)
+    async def store_value(self, key: str, value: str, ttl_seconds: int | None = None):
+        """Set a value in Redis. Every key expires, so nothing is retained forever."""
+        await self.client.set(
+            key, value, ex=ttl_seconds or self.config.retention_ttl_seconds
+        )
 
     async def get_value(self, key: str) -> str | None:
         """Get a value from Redis."""
         value = await self.client.get(key)
         return value.decode("utf-8") if value else None
+
+    async def get_ttl(self, key: str) -> int | None:
+        """Seconds left before the key expires, or None if it is missing or persistent."""
+        ttl = await self.client.ttl(key)
+        return ttl if ttl > 0 else None
+
+    async def delete_value(self, key: str) -> bool:
+        """Delete a key. True when a key was actually removed."""
+        return bool(await self.client.delete(key))

--- a/backend/app/interfaces/repositories_interfaces.py
+++ b/backend/app/interfaces/repositories_interfaces.py
@@ -15,5 +15,13 @@ class TextRepositoryInterface(ABC):
         """Retrieve text by file ID."""
 
     @abstractmethod
+    async def get_text_ttl(self, file_id: UUID) -> Optional[int]:
+        """Seconds left before the stored text expires, or None if it is gone."""
+
+    @abstractmethod
+    async def delete_text(self, file_id: UUID) -> bool:
+        """Delete stored text. True when something was removed."""
+
+    @abstractmethod
     async def save_batch(self, batch_id: UUID, file_ids: list[str]) -> None:
         """Save batch information."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,7 +37,8 @@ app.include_router(health_router, tags=["Health Check"])
 app.include_router(uploads_router, prefix="/api", tags=["Document Uploads"])
 app.include_router(extractions_router, prefix="/api", tags=["Text Extractions"])
 
-if os.getenv("APP_ENV", "development") == "development":
+# Default to production so the mock endpoints require an explicit opt-in.
+if os.getenv("APP_ENV", "production") == "development":
     app.include_router(mock_router)
 
 

--- a/backend/app/repositories/text_repository.py
+++ b/backend/app/repositories/text_repository.py
@@ -23,6 +23,14 @@ class RedisTextRepository(TextRepositoryInterface):
         """Retrieve text by file ID."""
         return await self._storage.get_value(str(file_id))
 
+    async def get_text_ttl(self, file_id: UUID) -> Optional[int]:
+        """Seconds left before the stored text expires, or None if it is gone."""
+        return await self._storage.get_ttl(str(file_id))
+
+    async def delete_text(self, file_id: UUID) -> bool:
+        """Delete stored text. True when something was removed."""
+        return await self._storage.delete_value(str(file_id))
+
     async def save_batch(self, batch_id: UUID, file_ids: list[str]) -> None:
         """Save batch information."""
         await self._storage.store_value(str(batch_id), str(file_ids))

--- a/backend/app/schemas/extraction.py
+++ b/backend/app/schemas/extraction.py
@@ -50,6 +50,10 @@ class ExtractionResponse(BaseModel):
         default=None,
         description="Information about the label mapping used (language, dataset)",
     )
+    expires_in_seconds: Optional[int] = Field(
+        default=None,
+        description="Seconds before the stored document is automatically deleted",
+    )
 
 
 class ErrorResponse(BaseModel):

--- a/backend/app/schemas/upload.py
+++ b/backend/app/schemas/upload.py
@@ -14,6 +14,10 @@ class UploadResponse(BaseModel):
     uploaded_at: Optional[datetime] = Field(
         default=None, description="Upload timestamp"
     )
+    expires_in_seconds: Optional[int] = Field(
+        default=None,
+        description="Seconds before the stored document is automatically deleted",
+    )
 
 
 class MultipleUploadResponse(BaseModel):

--- a/backend/app/services/text_extractor.py
+++ b/backend/app/services/text_extractor.py
@@ -1,3 +1,4 @@
+import logging
 from io import BytesIO
 from typing import Optional
 import fitz
@@ -6,31 +7,45 @@ from fastapi import UploadFile
 
 from app.interfaces.service_interfaces import TextExtractionServiceInterface
 
+logger = logging.getLogger(__name__)
+
+PDF_CONTENT_TYPE = "application/pdf"
+DOCX_CONTENT_TYPE = (
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+)
+PLAINTEXT_CONTENT_TYPE = "text/plain"
+SUPPORTED_CONTENT_TYPES = frozenset(
+    {PDF_CONTENT_TYPE, DOCX_CONTENT_TYPE, PLAINTEXT_CONTENT_TYPE}
+)
+
 
 class TextExtractor(TextExtractionServiceInterface):
     async def extract_text(self, file: UploadFile) -> Optional[str]:
         """
         Extracts text from the document based on its file type.
         """
-        try:
-            contents = await file.read()
-            file_bytes = BytesIO(contents)
+        if file.content_type not in SUPPORTED_CONTENT_TYPES:
+            raise ValueError("Unsupported file type")
 
-            if file.content_type == "application/pdf":
+        try:
+            file_bytes = BytesIO(await file.read())
+
+            if file.content_type == PDF_CONTENT_TYPE:
                 return self._extract_text_from_pdf(file_bytes)
 
-            if (
-                file.content_type
-                == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            ):
+            if file.content_type == DOCX_CONTENT_TYPE:
                 return self._extract_text_from_docx(file_bytes)
 
-            if file.content_type == "text/plain":
-                return self._extract_text_from_plaintext(file_bytes)
-
-            raise ValueError("Unsupported file type")
+            return self._extract_text_from_plaintext(file_bytes)
         except Exception as e:
-            raise ValueError(f"Error extracting text: {str(e)}") from e
+            # Parser errors routinely quote the bytes that failed to parse, so
+            # neither the message nor a traceback may reach the log or the caller.
+            logger.error(
+                "Text extraction failed for a %s document (%s)",
+                file.content_type,
+                type(e).__name__,
+            )
+            raise ValueError("Unable to extract text from the document") from e
 
     def _extract_text_from_pdf(self, file_bytes: BytesIO) -> str:
         text = ""

--- a/backend/tests/test_delete_document_route.py
+++ b/backend/tests/test_delete_document_route.py
@@ -1,0 +1,58 @@
+# pylint: disable=W0621
+import pytest
+from uuid import uuid4
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.routes.uploads import router
+from app.core.dependencies import get_text_repository
+from app.interfaces.repositories_interfaces import TextRepositoryInterface
+
+
+@pytest.fixture
+def mock_repository():
+    repository = MagicMock(spec=TextRepositoryInterface)
+    repository.delete_text = AsyncMock(return_value=True)
+    return repository
+
+
+@pytest.fixture
+def client(mock_repository):
+    # Mount the router alone: app.main pulls in the NER stack, which this
+    # endpoint does not touch.
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.dependency_overrides[get_text_repository] = lambda: mock_repository
+    return TestClient(app)
+
+
+def test_delete_document(client, mock_repository):
+    file_id = uuid4()
+
+    response = client.delete(f"/api/documents/{file_id}")
+
+    assert response.status_code == 204
+    mock_repository.delete_text.assert_called_once_with(file_id)
+
+
+def test_delete_document_not_found(client, mock_repository):
+    mock_repository.delete_text.return_value = False
+
+    response = client.delete(f"/api/documents/{uuid4()}")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["message"] == (
+        "Document not found or already expired."
+    )
+
+
+def test_delete_document_rejects_malformed_id(client, mock_repository):
+    response = client.delete("/api/documents/not-a-uuid")
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["message"] == (
+        "Invalid file ID format. Expected UUID."
+    )
+    mock_repository.delete_text.assert_not_called()

--- a/backend/tests/test_redis_storage.py
+++ b/backend/tests/test_redis_storage.py
@@ -10,6 +10,7 @@ from app.core.config import RedisConfiguration
 def mock_redis_config():
     config = MagicMock(spec=RedisConfiguration)
     config.url = "redis://localhost"
+    config.retention_ttl_seconds = 3600
     return config
 
 
@@ -26,13 +27,26 @@ def test_redis_storage_init(mock_from_url, mock_redis_config):
 
 @pytest.mark.asyncio
 @patch("app.db.redis.redis.Redis.from_url")
-async def test_store_value(mock_from_url, mock_redis_config):
+async def test_store_value_applies_configured_retention(
+    mock_from_url, mock_redis_config
+):
     mock_client = MagicMock()
     mock_client.set = AsyncMock()
     mock_from_url.return_value = mock_client
     storage = RedisStorage(mock_redis_config)
     await storage.store_value("test_key", "test_value")
-    mock_client.set.assert_called_once_with("test_key", "test_value")
+    mock_client.set.assert_called_once_with("test_key", "test_value", ex=3600)
+
+
+@pytest.mark.asyncio
+@patch("app.db.redis.redis.Redis.from_url")
+async def test_store_value_accepts_explicit_ttl(mock_from_url, mock_redis_config):
+    mock_client = MagicMock()
+    mock_client.set = AsyncMock()
+    mock_from_url.return_value = mock_client
+    storage = RedisStorage(mock_redis_config)
+    await storage.store_value("test_key", "test_value", ttl_seconds=60)
+    mock_client.set.assert_called_once_with("test_key", "test_value", ex=60)
 
 
 @pytest.mark.asyncio
@@ -57,3 +71,49 @@ async def test_get_value_none(mock_from_url, mock_redis_config):
     value = await storage.get_value("test_key")
     mock_client.get.assert_called_once_with("test_key")
     assert value is None
+
+
+@pytest.mark.asyncio
+@patch("app.db.redis.redis.Redis.from_url")
+async def test_get_ttl(mock_from_url, mock_redis_config):
+    mock_client = MagicMock()
+    mock_client.ttl = AsyncMock(return_value=42)
+    mock_from_url.return_value = mock_client
+    storage = RedisStorage(mock_redis_config)
+    assert await storage.get_ttl("test_key") == 42
+    mock_client.ttl.assert_called_once_with("test_key")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("redis_ttl", [-1, -2])
+@patch("app.db.redis.redis.Redis.from_url")
+async def test_get_ttl_missing_or_persistent_key(
+    mock_from_url, mock_redis_config, redis_ttl
+):
+    # Redis answers -2 for a missing key and -1 for a key without an expiry.
+    mock_client = MagicMock()
+    mock_client.ttl = AsyncMock(return_value=redis_ttl)
+    mock_from_url.return_value = mock_client
+    storage = RedisStorage(mock_redis_config)
+    assert await storage.get_ttl("test_key") is None
+
+
+@pytest.mark.asyncio
+@patch("app.db.redis.redis.Redis.from_url")
+async def test_delete_value(mock_from_url, mock_redis_config):
+    mock_client = MagicMock()
+    mock_client.delete = AsyncMock(return_value=1)
+    mock_from_url.return_value = mock_client
+    storage = RedisStorage(mock_redis_config)
+    assert await storage.delete_value("test_key") is True
+    mock_client.delete.assert_called_once_with("test_key")
+
+
+@pytest.mark.asyncio
+@patch("app.db.redis.redis.Redis.from_url")
+async def test_delete_value_missing_key(mock_from_url, mock_redis_config):
+    mock_client = MagicMock()
+    mock_client.delete = AsyncMock(return_value=0)
+    mock_from_url.return_value = mock_client
+    storage = RedisStorage(mock_redis_config)
+    assert await storage.delete_value("test_key") is False

--- a/backend/tests/test_text_extractor.py
+++ b/backend/tests/test_text_extractor.py
@@ -72,10 +72,27 @@ async def test_unsupported_file_type(text_extractor):
 
 
 @pytest.mark.asyncio
-async def test_extraction_error(text_extractor):
+async def test_extraction_error_message_carries_no_document_content(text_extractor):
     mock_file = AsyncMock(spec=UploadFile)
     mock_file.content_type = "application/pdf"
-    mock_file.read.side_effect = Exception("Test error")
+    mock_file.read.side_effect = Exception("failed at byte 42: Patient Jean Dupont")
 
-    with pytest.raises(ValueError, match="Error extracting text: Test error"):
+    with pytest.raises(ValueError) as exc_info:
         await text_extractor.extract_text(mock_file)
+
+    assert str(exc_info.value) == "Unable to extract text from the document"
+
+
+@pytest.mark.asyncio
+async def test_extraction_error_is_not_logged_with_document_content(
+    text_extractor, caplog
+):
+    mock_file = AsyncMock(spec=UploadFile)
+    mock_file.content_type = "application/pdf"
+    mock_file.read.side_effect = Exception("failed at byte 42: Patient Jean Dupont")
+
+    with pytest.raises(ValueError):
+        await text_extractor.extract_text(mock_file)
+
+    assert "Jean Dupont" not in caplog.text
+    assert "Text extraction failed" in caplog.text

--- a/backend/tests/test_text_repository.py
+++ b/backend/tests/test_text_repository.py
@@ -1,0 +1,70 @@
+# pylint: disable=W0621
+import pytest
+from uuid import uuid4
+from unittest.mock import AsyncMock, MagicMock
+
+from app.db.redis import RedisStorage
+from app.repositories.text_repository import RedisTextRepository
+
+
+@pytest.fixture
+def mock_storage():
+    storage = MagicMock(spec=RedisStorage)
+    storage.store_value = AsyncMock()
+    storage.get_value = AsyncMock(return_value="extracted text")
+    storage.get_ttl = AsyncMock(return_value=1800)
+    storage.delete_value = AsyncMock(return_value=True)
+    return storage
+
+
+@pytest.fixture
+def repository(mock_storage):
+    return RedisTextRepository(redis_storage=mock_storage)
+
+
+@pytest.mark.asyncio
+async def test_save_text(repository, mock_storage):
+    file_id = uuid4()
+    await repository.save_text(file_id, "extracted text")
+    mock_storage.store_value.assert_called_once_with(str(file_id), "extracted text")
+
+
+@pytest.mark.asyncio
+async def test_get_text(repository, mock_storage):
+    file_id = uuid4()
+    assert await repository.get_text(file_id) == "extracted text"
+    mock_storage.get_value.assert_called_once_with(str(file_id))
+
+
+@pytest.mark.asyncio
+async def test_get_text_ttl(repository, mock_storage):
+    file_id = uuid4()
+    assert await repository.get_text_ttl(file_id) == 1800
+    mock_storage.get_ttl.assert_called_once_with(str(file_id))
+
+
+@pytest.mark.asyncio
+async def test_get_text_ttl_expired(repository, mock_storage):
+    mock_storage.get_ttl.return_value = None
+    assert await repository.get_text_ttl(uuid4()) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_text(repository, mock_storage):
+    file_id = uuid4()
+    assert await repository.delete_text(file_id) is True
+    mock_storage.delete_value.assert_called_once_with(str(file_id))
+
+
+@pytest.mark.asyncio
+async def test_delete_text_missing_document(repository, mock_storage):
+    mock_storage.delete_value.return_value = False
+    assert await repository.delete_text(uuid4()) is False
+
+
+@pytest.mark.asyncio
+async def test_save_batch(repository, mock_storage):
+    batch_id = uuid4()
+    file_ids = [str(uuid4())]
+    await repository.save_batch(batch_id, file_ids)
+    mock_storage.store_value.assert_called_once_with(str(batch_id), str(file_ids))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,27 @@ version: '3.8'
 services:
   redis:
     image: redis:7-alpine
-    ports:
-      - "6379:6379"
     container_name: med_assist_redis
+    # No host port mapping: Redis is reachable only from the compose network.
+    # No RDB snapshot and no AOF: extracted clinical text never reaches the disk.
+    command:
+      - redis-server
+      - --save
+      - ""
+      - --appendonly
+      - "no"
+      - --maxmemory
+      - ${REDIS_MAXMEMORY:-256mb}
+      - --maxmemory-policy
+      - allkeys-lru
+      - --requirepass
+      - ${REDIS_PASSWORD:?set REDIS_PASSWORD in .env - see .env.example}
+    environment:
+      # Read by redis-cli so the healthcheck authenticates without exposing the
+      # password in the process list.
+      - REDISCLI_AUTH=${REDIS_PASSWORD}
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD-SHELL", "redis-cli ping | grep -q PONG"]
       interval: 5s
       timeout: 3s
       retries: 5
@@ -20,8 +36,11 @@ services:
       - "8000:8000"
     environment:
       - PYTHONUNBUFFERED=1
-      - REDIS_URL=redis://redis:6379/0
+      - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379/0
       - NER_MODEL_NAME=/app/models/
+      - RETENTION_TTL_SECONDS=${RETENTION_TTL_SECONDS:-3600}
+      # Development mode mounts the mock endpoints; production is the default.
+      - APP_ENV=${APP_ENV:-production}
     container_name: med_assist_backend
     depends_on:
       redis:
@@ -31,6 +50,10 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        # Baked into the client bundle at build time, so it must be the URL the
+        # browser uses to reach the backend - not the compose service name.
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8000}
     ports:
       - "3000:3000" # Exposes Next.js standalone server on host port 3000
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,6 +14,10 @@ RUN npm ci
 # Copy source code
 COPY . .
 
+# NEXT_PUBLIC_* values are inlined into the client bundle at build time.
+ARG NEXT_PUBLIC_API_URL=http://localhost:8000
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+
 # Build the Next.js application
 RUN npm run build
 

--- a/frontend/app/components/RetentionNotice.tsx
+++ b/frontend/app/components/RetentionNotice.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+interface Props {
+  expiresInSeconds: number
+}
+
+export function formatRemaining(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes} min`
+
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ${minutes % 60}min`
+}
+
+export default function RetentionNotice({ expiresInSeconds }: Props) {
+  const [remaining, setRemaining] = useState(expiresInSeconds)
+
+  useEffect(() => {
+    // Count down against a fixed deadline rather than decrementing a counter,
+    // so a throttled or suspended tab does not drift behind the server.
+    const deadline = Date.now() + expiresInSeconds * 1000
+    const timer = setInterval(() => {
+      setRemaining(Math.max(Math.round((deadline - Date.now()) / 1000), 0))
+    }, 1000)
+    return () => clearInterval(timer)
+  }, [expiresInSeconds])
+
+  return (
+    <p role="status" className="mt-2 text-sm text-gray-600">
+      {remaining > 0
+        ? `This document is deleted from the server in ${formatRemaining(remaining)}.`
+        : 'This document has been deleted from the server.'}
+    </p>
+  )
+}

--- a/frontend/app/components/__tests__/RetentionNotice.test.tsx
+++ b/frontend/app/components/__tests__/RetentionNotice.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+import RetentionNotice, { formatRemaining } from '../RetentionNotice'
+
+describe('formatRemaining', () => {
+  it('renders seconds below a minute', () => {
+    expect(formatRemaining(45)).toBe('45s')
+  })
+
+  it('renders whole minutes below an hour', () => {
+    expect(formatRemaining(3599)).toBe('59 min')
+  })
+
+  it('renders hours and minutes above an hour', () => {
+    expect(formatRemaining(3600)).toBe('1h 0min')
+    expect(formatRemaining(5460)).toBe('1h 31min')
+  })
+})
+
+describe('RetentionNotice', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('announces when the document disappears', () => {
+    render(<RetentionNotice expiresInSeconds={3600} />)
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'This document is deleted from the server in 1h 0min.'
+    )
+  })
+
+  it('counts down as time passes', () => {
+    render(<RetentionNotice expiresInSeconds={65} />)
+    act(() => {
+      vi.advanceTimersByTime(6000)
+    })
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'This document is deleted from the server in 59s.'
+    )
+  })
+
+  it('reports the document as gone once the window closes', () => {
+    render(<RetentionNotice expiresInSeconds={2} />)
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'This document has been deleted from the server.'
+    )
+  })
+})

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import axios from 'axios'
 import FileUpload from './components/FileUpload'
 import ExtractionViewer from './components/ExtractionViewer'
+import RetentionNotice from './components/RetentionNotice'
 
 interface EntityDetail {
   text: string
@@ -36,13 +37,15 @@ interface ExtractionData {
     dataset: string
     description: string
   }
+  expires_in_seconds?: number | null
 }
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
 
 export default function HomePage() {
   const [fileId, setFileId] = useState<string | null>(null)
   const [extraction, setExtraction] = useState<ExtractionData | null>(null)
+  const [expiresIn, setExpiresIn] = useState<number | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const handleFileUpload = async (file: File) => {
@@ -57,6 +60,7 @@ export default function HomePage() {
 
       if (response.status === 200) {
         setFileId(response.data.file_id)
+        setExpiresIn(response.data.expires_in_seconds ?? null)
         setExtraction(null)
       }
     } catch (err: unknown) {
@@ -64,6 +68,23 @@ export default function HomePage() {
         ? err.response?.data?.message || 'Failed to upload file'
         : 'Failed to upload file'
       setError(uploadErrorMessage)
+    }
+  }
+
+  const deleteDocument = async () => {
+    if (!fileId) return
+
+    try {
+      setError(null)
+      await axios.delete(`${API_URL}/api/documents/${fileId}`)
+      setFileId(null)
+      setExtraction(null)
+      setExpiresIn(null)
+    } catch (err: unknown) {
+      const deleteErrorMessage = axios.isAxiosError(err)
+        ? err.response?.data?.message || 'Failed to delete document'
+        : 'Failed to delete document'
+      setError(deleteErrorMessage)
     }
   }
 
@@ -75,6 +96,7 @@ export default function HomePage() {
       const response = await axios.get(`${API_URL}/api/get_extracted_text/${fileId}`)
       if (response.status === 200) {
         setExtraction(response.data)
+        setExpiresIn(response.data.expires_in_seconds ?? null)
       }
     } catch (err: unknown) {
       const extractionErrorMessage = axios.isAxiosError(err)
@@ -98,12 +120,24 @@ export default function HomePage() {
       {fileId && (
         <div className="mt-4">
           <p className="text-sm text-gray-600 mb-2">File ID: {fileId}</p>
-          <button
-            onClick={fetchExtraction}
-            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-          >
-            Extract Text
-          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={fetchExtraction}
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              Extract Text
+            </button>
+            <button
+              onClick={deleteDocument}
+              className="px-4 py-2 border border-gray-400 text-gray-700 rounded hover:bg-gray-100"
+            >
+              Delete Now
+            </button>
+          </div>
+          {expiresIn !== null && (
+            // Keyed so a freshly reported expiry restarts the countdown at once.
+            <RetentionNotice key={`${fileId}-${expiresIn}`} expiresInSeconds={expiresIn} />
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Why

The README makes three commitments: Med-Assist runs locally, runs light, and holds almost nothing about a patient. The local-first claim holds today — the NER model is mounted from `./models` and no request leaves the host. The retention and storage claims did not.

This is Phase 0 of the roadmap: six small, mechanical changes that close the distance between what the project says and what it does. None of them needed a design decision.

## What changed

### Retention and deletion

- **Every key now has a TTL.** Nothing in the codebase called `EXPIRE`, `SETEX` or `DELETE` — `store_value` issued a plain `SET`, so extracted clinical text lived until someone wiped the container by hand. Writes now carry an expiry from `RETENTION_TTL_SECONDS`, defaulting to one hour.
- **Added a delete path.** `DELETE /api/documents/{file_id}` with a matching `delete_text` on the repository interface: `204` on success, `404` when nothing was stored, `400` on a malformed id. Reachable from the UI via a "Delete Now" button.
- **The remaining time is visible.** Upload and extraction responses carry `expires_in_seconds`, and the interface counts it down, so a clinician knows when the document disappears.

### Boundaries

- **Hardened the Redis container.** No RDB snapshot and no AOF, so clinical text never reaches the disk; a memory ceiling with an eviction policy; a required password; and no host port mapping, so it is reachable only from the compose network.
- **The dev-only surface fails closed.** `APP_ENV` defaulted to `development`, which mounted the mock router unless the operator explicitly opted out. It now defaults to `production`.
- **Error strings no longer carry document content.** `extract_text` rewrapped every failure as `ValueError(f"Error extracting text: {str(e)}")`, and parser errors routinely quote the bytes that failed to parse. The caller now gets a fixed message, and only the content type and exception class name are logged.

### Fresh-clone fix

The frontend's API URL fell back to `http://localhost:8080` while the backend listens on 8000, and compose set no `NEXT_PUBLIC_API_URL` — a fresh clone could not talk to its own backend. Fixed, and plumbed through a Docker build arg since `NEXT_PUBLIC_*` is inlined at build time.

## Verification

- Backend: 44 tests pass. Ruff, ruff-format, mypy and pylint clean via `pre-commit run --all-files`.
- Frontend: 19 tests pass (6 new). ESLint clean, `next build` succeeds.
- Brought the hardened Redis container up and confirmed each property directly: an unauthenticated `SET` returns `NOAUTH`, `save` is empty, `appendonly` is `no`, `maxmemory` is 268435456 with `allkeys-lru`, and 6379 is unreachable from the host.
- Exercised the repository against a real Redis: the TTL is applied on save, delete removes the key and returns `False` on a second call, and a one-second key does expire.

## Notes for the reviewer

- **`REDIS_PASSWORD` is now required.** Every compose command needs `.env` present — `cp .env.example .env` and set a value. This is fail-closed by choice, following the "keep secrets in environment variables only" rule in `AGENTS.md` §9; happy to default it instead if you would rather a fresh clone start with no setup step.
- `parse_file_id` moved into `app/core/validation.py` and is now shared by the extraction and delete routes rather than duplicated.
- Phase 2's first item showed itself during this work: `uv sync` pulled the CUDA torch build and the whole `nvidia-*` wheel set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)